### PR TITLE
refactor: update js interop imports and method calls in ZstandardWeb class

### DIFF
--- a/zstandard_web/pubspec.yaml
+++ b/zstandard_web/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/landamessenger/zstandard/tree/master/zstandard_we
 
 environment:
   sdk: ^3.5.3
-  flutter: '>=3.3.0'
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   zstandard_platform_interface: ^1.3.27
-  web: ">=0.5.1 <2.0.0"
+  web: ">=1.0.0 <2.0.0"
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
Currently the zstandard_web package is not compatible with dart2wasm compilation.
This is because of the usage of the outdated js package.

I migrated the current js.context.callMethod functions to the equivalent web.window.callMethod functions.

I haven't yet tested the decompression/compression itself on web, so please check it before merging.